### PR TITLE
Adds improved denominator support for claiming rewards and tests

### DIFF
--- a/programs/gem_farm/src/state/farmer.rs
+++ b/programs/gem_farm/src/state/farmer.rs
@@ -271,7 +271,7 @@ impl FarmerFixedRateReward {
         if self.promised_schedule.denominator > 1 {
             let lower_bound = self.reward_lower_bound()?;
             let upper_bound = self.reward_upper_bound(now_ts)?;
-            upper_bound.try_sub(upper_bound.try_sub(lower_bound)?.try_rem(self.promised_schedule.denominator)?)
+            now_ts.try_sub(upper_bound.try_sub(lower_bound)?.try_rem(self.promised_schedule.denominator)?)
         } else {
             Ok(now_ts)
         }
@@ -282,7 +282,7 @@ impl FarmerFixedRateReward {
     pub fn newly_accrued_reward(&self, now_ts: u64, rarity_points: u64) -> Result<u64> {
         let start_from = self.time_from_staking_to_update()?;
         let end_at = self
-            .reward_upper_bound(now_ts)?
+            .reward_upper_bound(self.capped_now_ts(now_ts)?)?
             .try_sub(self.begin_staking_ts)?;
 
         self.promised_schedule

--- a/tests/gem-farm/fixed-rate/gem-farm.fixed-rate.staking.denominator.test.ts
+++ b/tests/gem-farm/fixed-rate/gem-farm.fixed-rate.staking.denominator.test.ts
@@ -1,0 +1,106 @@
+import chai, { assert } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {
+  defaultFarmConfig,
+  defaultFixedConfig,
+  fixedConfigWithDenominator,
+  GemFarmTester,
+} from '../gem-farm.tester';
+import { BN } from '@project-serum/anchor';
+import {
+  FixedRateConfig,
+  pause,
+  RewardType,
+  toBN,
+  WhitelistType,
+} from '../../../src';
+import { PublicKey } from '@solana/web3.js';
+import { createMetadata } from '../../metaplex';
+
+chai.use(chaiAsPromised);
+
+describe('staking (fixed rate)', () => {
+  let gf = new GemFarmTester();
+
+  beforeEach('preps accs', async () => {
+    await gf.prepAccounts(5000000000);
+    await gf.callInitFarm(defaultFarmConfig, RewardType.Fixed);
+    await gf.prepGemRarities();
+    await gf.callInitFarmer(gf.farmer1Identity);
+    await gf.callInitFarmer(gf.farmer2Identity);
+    await gf.callDeposit(gf.gem1Amount, gf.farmer1Identity);
+    await gf.callDeposit(gf.gem2Amount, gf.farmer2Identity);
+    await gf.callAuthorize();
+    await gf.callFundReward(undefined, fixedConfigWithDenominator,);
+  });
+
+  it('stakes -> accrues -> claims (multi farmer) -> ONLY ONE DAY -> NEW!', async () => {
+    // ----------------- stake + accrue
+    await gf.stakeAndVerify(gf.farmer1Identity);
+    await gf.stakeAndVerify(gf.farmer2Identity);
+
+    await pause(11000);
+
+    //manually refresh to update accrued rewards for each farmer
+    await gf.callRefreshFarmer(gf.farmer1Identity);
+    await gf.callRefreshFarmer(gf.farmer2Identity);
+
+    //verify counts
+    await gf.verifyStakedGemsAndFarmers(2);
+
+    //verify funds
+    const f1Reward = await gf.verifyFarmerReward(gf.farmer1Identity);
+    const f2Reward = await gf.verifyFarmerReward(gf.farmer2Identity);
+    assert(f1Reward.accruedReward.eq(gf.gem1Amount.mul(fixedConfigWithDenominator.schedule.baseRate)));
+    assert(f2Reward.accruedReward.eq(gf.gem2Amount.mul(fixedConfigWithDenominator.schedule.baseRate)));
+
+    console.log("Running verifyFarmerFixedRewardTimings");
+    
+    // ----------------- claim
+    await gf.callClaimRewards(gf.farmer1Identity);
+    await gf.callClaimRewards(gf.farmer2Identity);
+
+    // see that the reward is only equal to one interval reward...
+    const farmer1Reward = await gf.verifyFarmerReward(gf.farmer1Identity);
+    const paidout = new BN(gf.gem1Amount.mul(fixedConfigWithDenominator.schedule.baseRate));
+    assert(paidout.eq(farmer1Reward.paidOutReward));
+
+    await gf.verifyClaimedReward(gf.farmer1Identity);
+    await gf.verifyClaimedReward(gf.farmer2Identity);
+  });
+
+  it('Multi farmer.. stake -> accure (but not enough) -> attempt to claim before payout period -> get nothing!', async () => {
+    // ----------------- stake + accrue
+    await gf.stakeAndVerify(gf.farmer1Identity);
+    await gf.stakeAndVerify(gf.farmer2Identity);
+
+    await pause(5000); // 5s
+
+    //manually refresh to update accrued rewards for each farmer
+    await gf.callRefreshFarmer(gf.farmer1Identity);
+    await gf.callRefreshFarmer(gf.farmer2Identity);
+
+    //verify counts
+    await gf.verifyStakedGemsAndFarmers(2);
+
+    //verify funds
+    //await gf.verifyAccruedRewardsFixedsd();
+    const f1Reward = await gf.verifyFarmerReward(gf.farmer1Identity);
+    const f2Reward = await gf.verifyFarmerReward(gf.farmer2Identity);
+    assert(f1Reward.accruedReward.eq(new BN(0)));
+    assert(f2Reward.accruedReward.eq(new BN(0)));
+
+    // ----------------- claim
+    await gf.callClaimRewards(gf.farmer1Identity);
+    await gf.callClaimRewards(gf.farmer2Identity);
+
+    // see that the reward is only equal to one minute reward...
+    const farmer1Reward = await gf.verifyFarmerReward(gf.farmer1Identity);
+    const paidout = new BN(0);
+    assert(paidout.eq(farmer1Reward.paidOutReward));
+
+    await gf.verifyClaimedReward(gf.farmer1Identity);
+    await gf.verifyClaimedReward(gf.farmer2Identity);
+  });
+
+});

--- a/tests/gem-farm/fixed-rate/gem-farm.fixed-rate.staking.denominator.test.ts
+++ b/tests/gem-farm/fixed-rate/gem-farm.fixed-rate.staking.denominator.test.ts
@@ -19,11 +19,11 @@ import { createMetadata } from '../../metaplex';
 
 chai.use(chaiAsPromised);
 
-describe('staking (fixed rate)', () => {
+describe('staking (fixed rate w/ denominator)', () => {
   let gf = new GemFarmTester();
 
   beforeEach('preps accs', async () => {
-    await gf.prepAccounts(5000000000);
+    await gf.prepAccounts(5000000000, 1, 1);
     await gf.callInitFarm(defaultFarmConfig, RewardType.Fixed);
     await gf.prepGemRarities();
     await gf.callInitFarmer(gf.farmer1Identity);
@@ -31,74 +31,69 @@ describe('staking (fixed rate)', () => {
     await gf.callDeposit(gf.gem1Amount, gf.farmer1Identity);
     await gf.callDeposit(gf.gem2Amount, gf.farmer2Identity);
     await gf.callAuthorize();
-    await gf.callFundReward(undefined, fixedConfigWithDenominator,);
+    await gf.callFundReward(undefined, fixedConfigWithDenominator);
   });
 
-  it('stakes -> accrues -> claims (multi farmer) -> ONLY ONE DAY -> NEW!', async () => {
+  it('stakes -> refresh before first reward (2s) -> lastUpdatedTs no change -> refresh after first reward (14s) -> lastUpdatedTs change (10s) -> refresh farmer (18s) -> no change in lastUpdatedTs(10s)', async () => {
     // ----------------- stake + accrue
-    await gf.stakeAndVerify(gf.farmer1Identity);
-    await gf.stakeAndVerify(gf.farmer2Identity);
+    const farmer1 = await gf.stakeAndVerify(gf.farmer1Identity);
+    const farmer2 = await gf.stakeAndVerify(gf.farmer2Identity);
 
-    await pause(11000);
+    let lastUpdatedTs1 = new BN(
+      gf.reward === 'rewardA' ?
+      farmer1.rewardA.fixedRate['lastUpdatedTs'] :
+      farmer1.rewardB.fixedRate['lastUpdatedTs']
+    );
+    let lastUpdatedTs2 = new BN(
+      gf.reward === 'rewardA' ?
+      farmer2.rewardA.fixedRate['lastUpdatedTs'] :
+      farmer2.rewardB.fixedRate['lastUpdatedTs']
+    );
 
-    //manually refresh to update accrued rewards for each farmer
+    await pause(2000); // 2s
+
     await gf.callRefreshFarmer(gf.farmer1Identity);
     await gf.callRefreshFarmer(gf.farmer2Identity);
 
-    //verify counts
+    let f1Reward = await gf.verifyFarmerReward(gf.farmer1Identity);
+    let f2Reward = await gf.verifyFarmerReward(gf.farmer2Identity);
+
     await gf.verifyStakedGemsAndFarmers(2);
 
-    //verify funds
-    const f1Reward = await gf.verifyFarmerReward(gf.farmer1Identity);
-    const f2Reward = await gf.verifyFarmerReward(gf.farmer2Identity);
-    assert(f1Reward.accruedReward.eq(gf.gem1Amount.mul(fixedConfigWithDenominator.schedule.baseRate)));
-    assert(f2Reward.accruedReward.eq(gf.gem2Amount.mul(fixedConfigWithDenominator.schedule.baseRate)));
+    // lastUpdated should be the same because it's before denominator
+    assert(lastUpdatedTs1.eq(f1Reward.fixedRate.lastUpdatedTs));
+    assert(lastUpdatedTs2.eq(f2Reward.fixedRate.lastUpdatedTs));
 
-    console.log("Running verifyFarmerFixedRewardTimings");
+    await pause(12000); // 14s
+
+    await gf.callRefreshFarmer(gf.farmer1Identity);
+    await gf.callRefreshFarmer(gf.farmer2Identity);
+
+    //verify funds
+    f1Reward = await gf.verifyFarmerReward(gf.farmer1Identity);
+    f2Reward = await gf.verifyFarmerReward(gf.farmer2Identity);
+
+    // the time should be updated now to just previous time + denominator (not +16s)
+    assert(lastUpdatedTs1.eq(f1Reward.fixedRate.lastUpdatedTs.sub(fixedConfigWithDenominator.schedule.denominator)));
+    assert(lastUpdatedTs2.eq(f2Reward.fixedRate.lastUpdatedTs.sub(fixedConfigWithDenominator.schedule.denominator)));
     
+    lastUpdatedTs1 = f1Reward.fixedRate.lastUpdatedTs;
+    lastUpdatedTs2 = f2Reward.fixedRate.lastUpdatedTs;
+
+    await pause(4000); // 18s
+
+    f1Reward = await gf.verifyFarmerReward(gf.farmer1Identity);
+    f2Reward = await gf.verifyFarmerReward(gf.farmer2Identity);
+
+    // time should be the same as before
+    assert(lastUpdatedTs1.eq(f1Reward.fixedRate.lastUpdatedTs));
+    assert(lastUpdatedTs2.eq(f2Reward.fixedRate.lastUpdatedTs));
+
     // ----------------- claim
     await gf.callClaimRewards(gf.farmer1Identity);
     await gf.callClaimRewards(gf.farmer2Identity);
 
     // see that the reward is only equal to one interval reward...
-    const farmer1Reward = await gf.verifyFarmerReward(gf.farmer1Identity);
-    const paidout = new BN(gf.gem1Amount.mul(fixedConfigWithDenominator.schedule.baseRate));
-    assert(paidout.eq(farmer1Reward.paidOutReward));
-
-    await gf.verifyClaimedReward(gf.farmer1Identity);
-    await gf.verifyClaimedReward(gf.farmer2Identity);
-  });
-
-  it('Multi farmer.. stake -> accure (but not enough) -> attempt to claim before payout period -> get nothing!', async () => {
-    // ----------------- stake + accrue
-    await gf.stakeAndVerify(gf.farmer1Identity);
-    await gf.stakeAndVerify(gf.farmer2Identity);
-
-    await pause(5000); // 5s
-
-    //manually refresh to update accrued rewards for each farmer
-    await gf.callRefreshFarmer(gf.farmer1Identity);
-    await gf.callRefreshFarmer(gf.farmer2Identity);
-
-    //verify counts
-    await gf.verifyStakedGemsAndFarmers(2);
-
-    //verify funds
-    //await gf.verifyAccruedRewardsFixedsd();
-    const f1Reward = await gf.verifyFarmerReward(gf.farmer1Identity);
-    const f2Reward = await gf.verifyFarmerReward(gf.farmer2Identity);
-    assert(f1Reward.accruedReward.eq(new BN(0)));
-    assert(f2Reward.accruedReward.eq(new BN(0)));
-
-    // ----------------- claim
-    await gf.callClaimRewards(gf.farmer1Identity);
-    await gf.callClaimRewards(gf.farmer2Identity);
-
-    // see that the reward is only equal to one minute reward...
-    const farmer1Reward = await gf.verifyFarmerReward(gf.farmer1Identity);
-    const paidout = new BN(0);
-    assert(paidout.eq(farmer1Reward.paidOutReward));
-
     await gf.verifyClaimedReward(gf.farmer1Identity);
     await gf.verifyClaimedReward(gf.farmer2Identity);
   });

--- a/tests/gem-farm/gem-farm.tester.ts
+++ b/tests/gem-farm/gem-farm.tester.ts
@@ -58,6 +58,20 @@ export const defaultFixedConfig = <FixedRateConfig>{
   durationSec: new BN(100),
 };
 
+
+export const fixedConfigWithDenominator = <FixedRateConfig>{
+  schedule: {
+    // total 30 per gem
+    baseRate: toBN(1),
+    tier1: null,
+    tier2: null,
+    tier3: null,
+    denominator: toBN(10) 
+  },
+  amount: new BN(30000),
+  durationSec: new BN(30)
+};
+
 // --------------------------------------- tester class
 
 export class GemFarmTester extends GemFarmClient {


### PR DESCRIPTION
This solution fixes the refresh/claim issue with denominators > 1.

Basically, every time someone refreshes the farmer, the system takes the current time, evaluates how many rewards have been accrued and then updates the last_updated_ts to the current time or end of reward (whichever comes first). 

This is fine when the denominator is default. However, when the denominator is > 1 (e.g. 10), and someone refreshes before the denominator is reached, the farmer will receive 0 awards and the updated_ts will still the current time, losing the opportunity time between their last_updated_ts and now_ts.

This solution calculates an offset from the denominator with the current time and uses that as a way to round down the now_ts to the nearest previous interval. This ensures the farmer gets the maximum reward available to them, but sets the last_updated_ts to the exact time they receive their last reward (if they can receive rewards yet).

![Staking Denominator Fix Explanation](https://user-images.githubusercontent.com/1524593/155873610-8d93ca11-392b-4dc7-9e5a-601b284d6f9e.png)

