### PR TITLE
Last recorded accrued reward per gem is NaN

### DIFF
--- a/app/gem-farm/src/components/gem-farm/FarmerRewardDisplay.vue
+++ b/app/gem-farm/src/components/gem-farm/FarmerRewardDisplay.vue
@@ -9,7 +9,7 @@
         Last recorded accrued reward per gem:
         {{
           numeral(
-            reward.variableRate.lastRecordedAccruedRewardPerRarityPoint.n / 10 ** 15
+            reward.variableRate.lastRecordedAccruedRewardPerRarityPoint.n / 10 ** 3
           ).format('0,0.0')
         }}
       </div>


### PR DESCRIPTION
Fix the issue "Last recorded accrued reward per gem" is NaN.
![スクリーンショット 2022-03-29 19 55 39](https://user-images.githubusercontent.com/64312219/160596811-6d062b3e-c9cb-4889-9d7d-e09b7f07ffc8.png)

