### PR TITLE
Stakers can withdraw airdropped tokens.

### DIFF
--- a/programs/gem_bank/src/instructions/mod.rs
+++ b/programs/gem_bank/src/instructions/mod.rs
@@ -1,5 +1,4 @@
 pub mod add_to_whitelist;
-pub mod clean_vault;
 pub mod deposit_gem;
 pub mod init_bank;
 pub mod init_vault;
@@ -10,9 +9,9 @@ pub mod set_vault_lock;
 pub mod update_bank_manager;
 pub mod update_vault_owner;
 pub mod withdraw_gem;
+pub mod withdraw_tokens_vault;
 
 pub use add_to_whitelist::*;
-pub use clean_vault::*;
 pub use deposit_gem::*;
 pub use init_bank::*;
 pub use init_vault::*;
@@ -23,3 +22,4 @@ pub use set_vault_lock::*;
 pub use update_bank_manager::*;
 pub use update_vault_owner::*;
 pub use withdraw_gem::*;
+pub use withdraw_tokens_vault::*;

--- a/programs/gem_bank/src/instructions/mod.rs
+++ b/programs/gem_bank/src/instructions/mod.rs
@@ -9,7 +9,7 @@ pub mod set_vault_lock;
 pub mod update_bank_manager;
 pub mod update_vault_owner;
 pub mod withdraw_gem;
-pub mod withdraw_tokens_vault;
+pub mod withdraw_token_vault;
 
 pub use add_to_whitelist::*;
 pub use deposit_gem::*;
@@ -22,4 +22,4 @@ pub use set_vault_lock::*;
 pub use update_bank_manager::*;
 pub use update_vault_owner::*;
 pub use withdraw_gem::*;
-pub use withdraw_tokens_vault::*;
+pub use withdraw_token_vault::*;

--- a/programs/gem_bank/src/instructions/withdraw_token_vault.rs
+++ b/programs/gem_bank/src/instructions/withdraw_token_vault.rs
@@ -5,7 +5,7 @@ use anchor_spl::{
     token::{self, Mint, Token, TokenAccount, Transfer},
 };
 #[derive(Accounts)]
-pub struct WithdrawTokensFromVault<'info> {
+pub struct WithdrawTokenFromVault<'info> {
     #[account(mut)]
     pub owner: Signer<'info>,
     /// CHECK
@@ -29,7 +29,7 @@ pub struct WithdrawTokensFromVault<'info> {
     pub rent: Sysvar<'info, Rent>,
 }
 
-impl<'info> WithdrawTokensFromVault<'info> {
+impl<'info> WithdrawTokenFromVault<'info> {
     fn transfer_ctx(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
         CpiContext::new(
             self.token_program.to_account_info(),
@@ -42,7 +42,7 @@ impl<'info> WithdrawTokensFromVault<'info> {
     }
 }
 // Cleans the vault
-pub fn withdraw_tokens_vault(ctx: Context<WithdrawTokensFromVault>) -> Result<()> {
+pub fn withdraw_token_vault(ctx: Context<WithdrawTokenFromVault>) -> Result<()> {
     let vault: &Box<Account<Vault>> = &ctx.accounts.vault;
     let vault_ata: &Pubkey = &ctx.accounts.vault_ata.clone().key();
     let bank: &Pubkey = &ctx.accounts.bank.clone().key();
@@ -56,7 +56,7 @@ pub fn withdraw_tokens_vault(ctx: Context<WithdrawTokensFromVault>) -> Result<()
 
     let (gem_box_pda, _) = anchor_lang::prelude::Pubkey::find_program_address(
         &[
-            b"gem_deposit_receipt".as_ref(),
+            b"gem_box".as_ref(),
             vault.key().as_ref(),
             &ctx.accounts.mint.key().as_ref(),
         ],

--- a/programs/gem_bank/src/instructions/withdraw_tokens_vault.rs
+++ b/programs/gem_bank/src/instructions/withdraw_tokens_vault.rs
@@ -1,9 +1,11 @@
 use crate::state::*;
 use anchor_lang::prelude::*;
-use anchor_spl::token::{self, Mint, Token, TokenAccount, Transfer};
-
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    token::{self, Mint, Token, TokenAccount, Transfer},
+};
 #[derive(Accounts)]
-pub struct CleanVault<'info> {
+pub struct WithdrawTokensFromVault<'info> {
     #[account(mut)]
     pub owner: Signer<'info>,
     /// CHECK
@@ -13,13 +15,21 @@ pub struct CleanVault<'info> {
     pub vault_ata: Account<'info, TokenAccount>,
     #[account(mut, has_one = bank, has_one = owner, has_one = authority)] //
     pub vault: Box<Account<'info, Vault>>,
-    #[account(mut)]
+    #[account(init_if_needed,
+        associated_token::mint = mint,
+        associated_token::authority = owner,
+        payer = owner)]
     pub recipient_ata: Account<'info, TokenAccount>,
-    pub mint: Account<'info, Mint>,
+    // pub mint: Account<'info, Mint>,
+    pub mint: Box<Account<'info, Mint>>,
     pub token_program: Program<'info, Token>,
     pub bank: Box<Account<'info, Bank>>,
+    pub system_program: Program<'info, System>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub rent: Sysvar<'info, Rent>,
 }
-impl<'info> CleanVault<'info> {
+
+impl<'info> WithdrawTokensFromVault<'info> {
     fn transfer_ctx(&self) -> CpiContext<'_, '_, '_, 'info, Transfer<'info>> {
         CpiContext::new(
             self.token_program.to_account_info(),
@@ -32,25 +42,37 @@ impl<'info> CleanVault<'info> {
     }
 }
 // Cleans the vault
-pub fn clean_vault(ctx: Context<CleanVault>) -> Result<()> {
+pub fn withdraw_tokens_vault(ctx: Context<WithdrawTokensFromVault>) -> Result<()> {
     let vault: &Box<Account<Vault>> = &ctx.accounts.vault;
-    let vault_ata_balance: u64 = ctx.accounts.vault_ata.amount;
+    let vault_ata: &Pubkey = &ctx.accounts.vault_ata.clone().key();
     let bank: &Pubkey = &ctx.accounts.bank.clone().key();
     let creator: &Pubkey = &&vault.creator;
 
-    // Seeds
+    // bump for vault PDA
     let seed = &[b"vault".as_ref(), bank.as_ref(), &&vault.creator.as_ref()];
-    let (_ata_address, bump2) =
+    let (vault_pda, bump2) =
         anchor_lang::prelude::Pubkey::find_program_address(seed, &ctx.program_id);
-
     let seed_with_bump = &[b"vault".as_ref(), bank.as_ref(), creator.as_ref(), &[bump2]];
+
+    let (gem_box_pda, _) = anchor_lang::prelude::Pubkey::find_program_address(
+        &[
+            b"gem_deposit_receipt".as_ref(),
+            vault.key().as_ref(),
+            &ctx.accounts.mint.key().as_ref(),
+        ],
+        &ctx.program_id,
+    );
+
+    //  vault_ata != gem_box PDA
+    assert_ne!(gem_box_pda, *vault_ata);
+    assert_ne!(gem_box_pda, vault_pda);
 
     // Transfer full balance to the recipient ATA
     token::transfer(
         ctx.accounts
             .transfer_ctx()
             .with_signer(&[&seed_with_bump[..]]),
-        vault_ata_balance,
+        ctx.accounts.vault_ata.amount,
     )?;
     Ok(())
 }

--- a/programs/gem_bank/src/lib.rs
+++ b/programs/gem_bank/src/lib.rs
@@ -70,7 +70,7 @@ pub mod gem_bank {
         instructions::record_rarity_points::handler(ctx, rarity_configs)
     }
 
-    pub fn clean_vault(ctx: Context<CleanVault>) -> Result<()> {
-        instructions::clean_vault::clean_vault(ctx)
+    pub fn clean_vault(ctx: Context<WithdrawTokensFromVault>) -> Result<()> {
+        instructions::withdraw_tokens_vault::withdraw_tokens_vault(ctx)
     }
 }

--- a/programs/gem_bank/src/lib.rs
+++ b/programs/gem_bank/src/lib.rs
@@ -70,7 +70,7 @@ pub mod gem_bank {
         instructions::record_rarity_points::handler(ctx, rarity_configs)
     }
 
-    pub fn clean_vault(ctx: Context<WithdrawTokensFromVault>) -> Result<()> {
-        instructions::withdraw_tokens_vault::withdraw_tokens_vault(ctx)
+    pub fn withdraw_token_from_vault(ctx: Context<WithdrawTokenFromVault>) -> Result<()> {
+        instructions::withdraw_token_vault::withdraw_token_vault(ctx)
     }
 }

--- a/src/gem-bank/gem-bank.client.ts
+++ b/src/gem-bank/gem-bank.client.ts
@@ -634,6 +634,9 @@ export class GemBankClient extends AccountUtils {
         mint: mint,
         tokenProgram: TOKEN_PROGRAM_ID,
         bank: bank,
+        systemProgram: SystemProgram.programId,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
       })
       .signers([owner])
       .rpc();

--- a/src/gem-bank/gem-bank.client.ts
+++ b/src/gem-bank/gem-bank.client.ts
@@ -613,7 +613,7 @@ export class GemBankClient extends AccountUtils {
     return { whitelistProof, whitelistBump, txSig };
   }
 
-  async cleanVault(
+  async withdrawTokenFromVault(
     owner: Keypair,
     vaultAta: PublicKey,
     vault: PublicKey,
@@ -624,7 +624,7 @@ export class GemBankClient extends AccountUtils {
     bump: number
   ) {
     await this.bankProgram.methods
-      .cleanVault()
+      .withdrawTokenFromVault()
       .accounts({
         owner: owner.publicKey,
         authority: vaultAuth,

--- a/src/types/gem_bank.ts
+++ b/src/types/gem_bank.ts
@@ -493,6 +493,21 @@ export type GemBank = {
           name: 'bank';
           isMut: false;
           isSigner: false;
+        },
+        {
+          name: 'systemProgram';
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: 'associatedTokenProgram';
+          isMut: false;
+          isSigner: false;
+        },
+        {
+          name: 'rent';
+          isMut: false;
+          isSigner: false;
         }
       ];
       args: [];
@@ -1235,6 +1250,21 @@ export const IDL: GemBank = {
         },
         {
           name: 'bank',
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: 'systemProgram',
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: 'associatedTokenProgram',
+          isMut: false,
+          isSigner: false,
+        },
+        {
+          name: 'rent',
           isMut: false,
           isSigner: false,
         },

--- a/src/types/gem_bank.ts
+++ b/src/types/gem_bank.ts
@@ -451,7 +451,7 @@ export type GemBank = {
       ];
     },
     {
-      name: 'cleanVault';
+      name: 'withdrawTokenFromVault';
       accounts: [
         {
           name: 'owner';
@@ -1210,7 +1210,7 @@ export const IDL: GemBank = {
       ],
     },
     {
-      name: 'cleanVault',
+      name: 'withdrawTokenFromVault',
       accounts: [
         {
           name: 'owner',

--- a/tests/gem-bank/withdraw-token-vault.test.ts
+++ b/tests/gem-bank/withdraw-token-vault.test.ts
@@ -342,7 +342,7 @@ describe('Withdraw tokens from vault', () => {
 
       let randomDude: Keypair = Keypair.generate();
       try {
-        let tr = await gb.cleanVault(
+        await gb.withdrawTokenFromVault(
           randomDude,
           vaultAta_bonk,
           vault,
@@ -373,7 +373,7 @@ describe('Withdraw tokens from vault', () => {
       );
 
       try {
-        let tr = await gb.cleanVault(
+        await gb.withdrawTokenFromVault(
           vaultOwner,
           gemBoxAcc.address,
           gemBox,
@@ -425,7 +425,7 @@ describe('Withdraw tokens from vault', () => {
       console.log('[FBNK] Vault balance start:', vaultFakeBonkStart);
       console.log('[FBNK] Recipient balance start:', recipientFakeBonkStart);
 
-      await gb.cleanVault(
+      await gb.withdrawTokenFromVault(
         vaultOwner,
         vaultAta_bonk,
         vault,


### PR DESCRIPTION
## Description

Requesting to make a pull request to **gem-farm** repo in order to add additional functionality regarding BONK and other airdropped tokens in the vault ATA. Instruction added to **gem-bank** in file [clean_vault.rs](https://github.com/sausage-dog/gem-farm/blob/main/programs/gem_bank/src/instructions/clean_vault.rs) allows to withdraw the SPL token balance to the account provided.

## Current Behaviour 

Users are unable to withdraw the airdropped tokens currently stuck in the vault PDA managed by them. 

## New Behaviour

Depositor able to withdraw any  SPL token held in an ATA managed by their vault PDA to any address. 


## Motivation and Context

Lot's of people have tokens that they are unable to claim as the withdraw authority is the program and it does not have the correct logic to allow them to withdrawal airdropped tokens currently stuck.

## How Has This Been Tested?


Tests are added onto the current gem-farm test script, showing seamless integration.
There are 3 tests included in file [gem-clean-vault.test.ts](https://github.com/sausage-dog/gem-farm/blob/main/tests/gem-bank/gem-clean-vault.test.ts).


For local testing: clone the repo - yarn - anchor test - (swap out programs IDs). 
Note: works with ts-mocha@10.0.0 due to Anchor.

No changes to the **gem-farm** program.

